### PR TITLE
Update icon system and introduce static copy plugin

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,7 +1,7 @@
 import type { Preview } from '@storybook/vue3'
 import { setup } from '@storybook/vue3'
-import { addIcons } from '@src/components/icon/icons.ts'
-import { ICONS } from '@src/stories/config/icons.ts'
+import { addIcons } from '@src/components/icon/icons'
+import { ICONS } from '@src/stories/config/icons'
 import './css/tailwind.css'
 
 setup(async () => {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,12 @@
 import type { Preview } from '@storybook/vue3'
+import { setup } from '@storybook/vue3'
+import { addIcons } from '@src/components/icon/icons.ts'
+import { ICONS } from '@src/stories/config/icons.ts'
 import './css/tailwind.css'
+
+setup(async () => {
+  addIcons(ICONS)
+})
 
 const preview: Preview = {
   parameters: {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
       "require": "./dist/index.js"
     },
     "./components/*": "./dist/components/*",
+    "./assets/*": "./dist/assets/*",
     "./config": "./scripts/config/index.js"
   },
   "files": [
@@ -79,6 +80,7 @@
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",
     "vite": "^6.2.0",
+    "vite-plugin-static-copy": "^2.3.1",
     "vitest": "^3.0.8",
     "vue-eslint-parser": "^10.1.1",
     "vue-tsc": "^2.2.4"

--- a/src/components/icon/UiIcon.types.ts
+++ b/src/components/icon/UiIcon.types.ts
@@ -5,7 +5,7 @@ export type IconSizes = {
   width: IconSize
 }
 
-export type IconProps = {
+export interface IconProps {
   name?: string
   src?: string
   size?: IconSize

--- a/src/components/icon/UiIcon.types.ts
+++ b/src/components/icon/UiIcon.types.ts
@@ -6,7 +6,7 @@ export type IconSizes = {
 }
 
 export type IconProps = {
-  icon?: string
+  name?: string
   src?: string
   size?: IconSize
 }

--- a/src/components/icon/UiIcon.vue
+++ b/src/components/icon/UiIcon.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import type { IconSize, IconSizes, IconProps } from './UiIcon.types.ts'
+import type { IconSize, IconSizes, IconProps } from './UiIcon.types'
 import { computed } from 'vue'
-import { icons } from './icons.ts'
+import { icons } from './icons'
 
 const SIZE_CLASSES_LIST: Record<IconSize, string> = {
   '16': 'w-4 h-4',
@@ -25,7 +25,7 @@ const iconRaw = computed(() => {
 const iconSize = computed((): IconSizes => {
   return { height: props.size, width: props.size }
 })
-const className = computed(() => SIZE_CLASSES_LIST[props.size])
+const className = computed(() => `ui-icon ${SIZE_CLASSES_LIST[props.size]}`)
 </script>
 
 <template>

--- a/src/components/icon/UiIcon.vue
+++ b/src/components/icon/UiIcon.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { IconSize, IconSizes, IconProps } from './UiIcon.types.ts'
 import { computed } from 'vue'
+import { icons } from './icons.ts'
 
 const SIZE_CLASSES_LIST: Record<IconSize, string> = {
   '16': 'w-4 h-4',
@@ -15,6 +16,12 @@ const props = withDefaults(defineProps<IconProps>(), {
   size: '24'
 })
 
+const iconRaw = computed(() => {
+  if (!props.name) {
+    return
+  }
+  return icons[props.name]
+})
 const iconSize = computed((): IconSizes => {
   return { height: props.size, width: props.size }
 })
@@ -22,6 +29,6 @@ const className = computed(() => SIZE_CLASSES_LIST[props.size])
 </script>
 
 <template>
-  <div v-if="icon && !src" :class="className" v-html="icon" />
+  <div v-if="iconRaw && !src" :class="className" v-html="iconRaw" />
   <img v-else v-bind="iconSize" :class="className" :src="src || undefined" alt="icon" />
 </template>

--- a/src/components/icon/icons.ts
+++ b/src/components/icon/icons.ts
@@ -1,0 +1,11 @@
+export const icons: Record<string, string> = {}
+
+export const addIcon = (name: string, icon: string) => {
+  icons[name] = icon
+}
+
+export const addIcons = (iconsSet: Record<string, string>) => {
+  Object.entries(iconsSet).forEach(([name, icon]) => {
+    icons[name] = icon
+  })
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,4 +3,4 @@ import UiIcon from './icon/UiIcon.vue'
 import UiImage from './image/Image.vue'
 
 export { UiButton, UiIcon, UiImage }
-export { addIcon, addIcons } from './icon/icons.ts'
+export { addIcon, addIcons } from './icon/icons'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,4 @@ import UiIcon from './icon/UiIcon.vue'
 import UiImage from './image/Image.vue'
 
 export { UiButton, UiIcon, UiImage }
+export { addIcon, addIcons } from './icon/icons.ts'

--- a/src/stories/components/Icon.stories.ts
+++ b/src/stories/components/Icon.stories.ts
@@ -16,7 +16,7 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     color: { control: 'color' },
-    icon: { control: 'select', options: names },
+    name: { control: 'select', options: names },
     src: { control: 'select', options: ICONS_LIST },
     size: { control: 'select', options: ['16', '20', '24', '32', '40', '48'] }
   },
@@ -32,7 +32,6 @@ const meta = {
         args: computed(() => {
           return {
             ...args,
-            icon: args.icon ? ICONS[args.icon] : '',
             style: { color: args.color }
           }
         })
@@ -51,7 +50,7 @@ type Story = StoryObj<typeof meta>
  */
 export const SvgIcon: Story = {
   args: {
-    icon: names[0],
+    name: names[0],
     src: ''
   },
   argTypes: {
@@ -61,12 +60,12 @@ export const SvgIcon: Story = {
 
 export const ImageIcon: Story = {
   args: {
-    icon: '',
+    name: '',
     src: ICONS_LIST[0]
   },
   argTypes: {
     color: { table: { disable: true } },
-    icon: { table: { disable: true } }
+    name: { table: { disable: true } }
   }
 }
 
@@ -80,7 +79,7 @@ const listTemplate = `
       class="flex flex-col gap-2 items-center justify-center"
     >
       <div class="flex w-32 h-32 items-center justify-center rounded-xl text-slate-900 ring-1 ring-inset ring-slate-900/[0.08]">
-        <UiIcon :icon="icons[name]" class="m-auto" />
+        <UiIcon :name="name" class="m-auto" />
       </div>
       <span class="text-xs">{{ name }}</span>
     </li>
@@ -91,7 +90,7 @@ const listTemplate = `
 export const ListOfSvgIcons: Story = {
   render: () => ({
     components: { UiIcon },
-    setup: () => ({ names, icons: ICONS }),
+    setup: () => ({ names }),
     template: listTemplate
   }),
   parameters: {

--- a/src/stories/config/icons.ts
+++ b/src/stories/config/icons.ts
@@ -40,7 +40,7 @@ export const ICONS_LIST = [
   '/assets/icons/youtube.svg'
 ]
 
-export const ICONS: Record<string, unknown> = {
+export const ICONS: Record<string, string> = {
   address,
   arrowRight,
   cashback,

--- a/vite.lib.ts
+++ b/vite.lib.ts
@@ -3,6 +3,7 @@ import { dirname, resolve, relative, extname } from 'node:path'
 import { globSync } from 'glob'
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import { viteStaticCopy } from 'vite-plugin-static-copy'
 import pkg from './package.json'
 
 const dirName = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url))
@@ -10,7 +11,6 @@ const dirName = typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLTo
 // https://vite.dev/config/
 export default defineConfig({
   build: {
-    // cssCodeSplit: true,
     copyPublicDir: false,
     lib: {
       entry: resolve(dirName, 'src/index.ts'),
@@ -31,14 +31,14 @@ export default defineConfig({
         })
       ),
       output: {
-        // assetFileNames: 'lib/assets/[name][extname]',
+        assetFileNames: 'lib/assets/[name][extname]',
         chunkFileNames: (file) => {
-          const name = file.name.split('.')[0].toLowerCase()
+          const name = file.name.split('.')[0]
           return `lib/${name}.chunk.js`
         },
         entryFileNames: (file) => {
           if (file.name.includes('components')) {
-            return `${file.name.toLowerCase()}.js`
+            return `${file.name}.js`
           }
 
           return `${file.name}.js`
@@ -49,5 +49,5 @@ export default defineConfig({
       }
     }
   },
-  plugins: [vue()]
+  plugins: [vue(), viteStaticCopy({ targets: [{ src: 'src/assets', dest: '' }] })]
 })

--- a/vite.lib.ts
+++ b/vite.lib.ts
@@ -31,7 +31,6 @@ export default defineConfig({
         })
       ),
       output: {
-        assetFileNames: 'lib/assets/[name][extname]',
         chunkFileNames: (file) => {
           const name = file.name.split('.')[0]
           return `lib/${name}.chunk.js`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,7 +1963,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
   integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
-fast-glob@^3.2.9, fast-glob@^3.3.2:
+fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
@@ -2055,6 +2055,15 @@ fraction.js@^4.3.7:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
+
+fs-extra@^11.1.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
+  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fsevents@2.3.2:
   version "2.3.2"
@@ -2165,7 +2174,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.6:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -2459,7 +2468,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-jsonfile@^6.1.0:
+jsonfile@^6.0.1, jsonfile@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
   integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
@@ -2771,6 +2780,11 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-map@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-7.0.3.tgz#7ac210a2d36f81ec28b736134810f7ba4418cdb6"
+  integrity sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==
 
 package-json-from-dist@^1.0.0:
   version "1.0.1"
@@ -3738,6 +3752,17 @@ vite-node@3.0.9:
     es-module-lexer "^1.6.0"
     pathe "^2.0.3"
     vite "^5.0.0 || ^6.0.0"
+
+vite-plugin-static-copy@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.1.tgz#f3b9ce44529d7728b2b61837ac18e06791489e06"
+  integrity sha512-EfsPcBm3ewg3UMG8RJaC0ADq6/qnUZnokXx4By4+2cAcipjT9i0Y0owIJGqmZI7d6nxk4qB1q5aXOwNuSyPdyA==
+  dependencies:
+    chokidar "^3.5.3"
+    fast-glob "^3.2.11"
+    fs-extra "^11.1.0"
+    p-map "^7.0.3"
+    picocolors "^1.0.0"
 
 "vite@^5.0.0 || ^6.0.0", vite@^6.2.0:
   version "6.2.2"


### PR DESCRIPTION
Replaced 'icon' prop with 'name' in UiIcon for clarity and added support for managing icons via a new utility. Integrated vite-plugin-static-copy to handle asset copying and adjusted related configs.